### PR TITLE
Bugfix/info birth

### DIFF
--- a/src/features/UserAccount/Section/validation.js
+++ b/src/features/UserAccount/Section/validation.js
@@ -1,47 +1,69 @@
 export const nameValidation = (value) => {
   return {
-      success: true,
-      error: ''
-    }
-}
-
+    success: true,
+    error: ""
+  };
+};
 
 export const dateValidation = (value) => {
   let success = false;
-  let error = '';
+  let error = "";
 
   const numberReg = /^[0-9/]*$/g;
-  const thisYear = new Date().getFullYear();
 
   if (!numberReg.test(value)) {
-      success = false;
-      error = '* 숫자 외의 문자는 입력할 수 없습니다.';
-  } else if (value.length === 4 && value > thisYear) {
-      success = false;
-      error = '* 잘못된 형식입니다.';
-  } else if (value.length === 7) {
-     if (value.substr(5, 2) < 1 || value.substr(5, 2) > 12) {
-      success = false;
-      error = '* 잘못된 형식입니다.';
-    }
-  } else if (value.length === 10) {
-    if (value.substr(8, 2) < 1 || value.substr(8, 2) > 31) {
-      success = false;
-      error = '* 잘못된 형식입니다.';
-    }
+    success = false;
+    error = "* 숫자 외의 문자는 입력할 수 없습니다.";
+  } else if (value.length > 2 && (!["1", "2"].includes(value[0]))) {
+    success = false;
+    error = "* 잘못된 날짜 형식입니다.";
+  } else if (value.length > 2 && !["9", "0"].includes(value[1])) {
+    success = false;
+    error = "* 잘못된 날짜 형식입니다.";
+  } else if (value.length > 5 && !["0", "1"].includes(value[5])) {
+    success = false;
+    error = "* 잘못된 날짜 형식입니다.";
+  } else if (
+    value.length > 6 &&
+    (Number(value.slice(5, 7)) > 12 || Number(value.slice(5, 7)) < 1)
+  ) {
+    success = false;
+    error = "* 잘못된 날짜 형식입니다.";
+  } else if (
+    value.length > 8 &&
+    !["1", "3", "5", "7", "8", "10", "12"].includes(
+      Number(value.slice(5, 7))
+    ) &&
+    (Number(value.slice(8, 10)) > 31 || Number(value.slice(8, 10)) < 1)
+  ) {
+    success = false;
+    error = "* 잘못된 날짜 형식입니다.";
+  } else if (
+    value.length > 8 &&
+    !["4", "6", "9", "11"].includes(Number(value.slice(5, 7))) &&
+    (Number(value.slice(8, 10)) > 30 || Number(value.slice(8, 10)) < 1)
+  ) {
+    success = false;
+    error = "* 잘못된 날짜 형식입니다.";
+  } else if (
+    value.length > 8 &&
+    !["2"].includes(Number(value.slice(5, 7))) &&
+    (Number(value.slice(8, 10)) > 29 || Number(value.slice(8, 10)) < 1)
+  ) {
+    success = false;
+    error = "* 잘못된 날짜 형식입니다.";
   } else {
     success = true;
-    error = '';
+    error = "";
   }
 
   return {
     success: success,
     error: error
-  }
-}
-
+  };
+};
 
 export const switched = (name, value) => {
-  if (name === 'nickname') return nameValidation(value)
-  else if (name === 'date') return dateValidation(value);
+  if (name === "nickname") return nameValidation(value);
+  else if (name === "date") return dateValidation(value);
 };

--- a/src/features/UserAccount/UserAccount.jsx
+++ b/src/features/UserAccount/UserAccount.jsx
@@ -34,10 +34,6 @@ const UserAccount = () => {
     }
   }, [dispatch, navigate]);
 
-  // useEffect(() => {
-  //   dispatch(getLoggedInfo())
-  // }, [loggedInfo])
-
   return (
     <>
       <Header />
@@ -48,12 +44,14 @@ const UserAccount = () => {
         >
           회원정보 수정
         </Tab>
-        <Tab
-          color={clicked ? "#A7A7A7" : "#3884FD"}
-          onClick={() => setClicked(false)}
-        >
-          비밀번호 변경
-        </Tab>
+        {loggedInfo?.provider !== "local" && (
+          <Tab
+            color={clicked ? "#A7A7A7" : "#3884FD"}
+            onClick={() => setClicked(false)}
+          >
+            비밀번호 변경
+          </Tab>
+        )}
       </Nav>
       <ContentWrap>
         <Section>


### PR DESCRIPTION
## 구현 목록

- 생년월일 유효성 검사 수정
- 현재 로그인된 유저의 provider에 따라 비밀번호 변경 여부 수정
## 변경점
### 생년월일 관련 수정
- 회원정보 수정 페이지에서 생년월일 작성 시 특별한 에러가 없음에도 불구하고 더 이상 작성되지 않는 버그를 발견하였습니다.
- 해당 버그는 validation 과정 중 입력값의 길이를 하드코딩하여 고정적으로 사용하였기 때문에 발생한 버그입니다.
- 수정 시 validation의 범위를 유동적으로 변경하고 더 디테일한 검사를 붙여 적용하였습니다.
<img width="525" alt="스크린샷 2023-06-10 오전 12 32 15" src="https://github.com/TravelRole/roleTravel-frontend/assets/111689342/6526f5b9-615d-4d06-b506-498ccf0b0199">

### 비밀번호 변경 페이지 접근 관련 수정
- 카카오 소셜 로그인의 경우 비밀번호가 변경되지 않는다고 합니다
- provider가 local인 경우에만 비밀번호 변경 페이지에 접근할 수 있게 핸들링했습니다.
<img width="753" alt="스크린샷 2023-06-10 오전 12 54 02" src="https://github.com/TravelRole/roleTravel-frontend/assets/111689342/a0e90ca5-a34f-476c-af0a-a65501a931f0">

